### PR TITLE
Temporary Patch: Show news for every course, even if settings are not activated

### DIFF
--- a/Services/News/classes/class.ilNewsItem.php
+++ b/Services/News/classes/class.ilNewsItem.php
@@ -876,7 +876,8 @@ class ilNewsItem
         // get starting date
         $starting_date = "";
         if ($obj_type == "grp" || $obj_type == "crs" || $obj_type == "cat") {
-            if (!ilContainer::_lookupContainerSetting(
+            // HSLU Temporary Patch to show news of courses even if the settings are not activated
+            /*if (!ilContainer::_lookupContainerSetting(
                 $obj_id,
                 'cont_use_news',
                 true
@@ -891,8 +892,8 @@ class ilNewsItem
                 )
             )) {
                 return [];
-            }
-
+            }*/
+            // HSLU Temporary Patch to show news of courses even if the settings are not activated
             include_once("./Services/Block/classes/class.ilBlockSetting.php");
             $hide_news_per_date = ilBlockSetting::_lookup(
                 "news",


### PR DESCRIPTION
According to mantis issue 28875, the behavior of the news feature are in ILIAS 6 not the same as in ILIAS 5.4.

As it turns out, there is a setting to turn the news in a course on. Since none of our courses have this option enabled (because it never was a requirement till now), I suggest to turn it on per default for the courses in the next semester and all succeeding courses (and for groups as well).

During the meantime, this temporary patch will tackle the issue with the current ongoing courses, which don't have the news feature activated.