### PR TITLE
PATCH HSLU: Temp fix for downloading nested empty folders

### DIFF
--- a/Services/BackgroundTasks/classes/Jobs/class.ilCopyFilesToTempDirectoryJob.php
+++ b/Services/BackgroundTasks/classes/Jobs/class.ilCopyFilesToTempDirectoryJob.php
@@ -135,7 +135,7 @@ class ilCopyFilesToTempDirectoryJob extends AbstractJob
                 // if the "file" to be copied is an empty folder the directory has to be created so it will be contained in the download zip
                 $is_empty_folder = preg_match_all("/\/$/", $copy_task[ilCopyDefinition::COPY_TARGET_DIR]);
                 if ($is_empty_folder) {
-                    mkdir($tmpdir . '/' . $copy_task[ilCopyDefinition::COPY_TARGET_DIR]);
+                    mkdir($tmpdir . '/' . $copy_task[ilCopyDefinition::COPY_TARGET_DIR], 0777, true);
                     $this->logger->notice('Empty folder has been created: ' . $tmpdir . '/' . $copy_task[ilCopyDefinition::COPY_SOURCE_DIR]);
                 } else {
                     $this->logger->notice('Cannot find file: ' . $copy_task[ilCopyDefinition::COPY_SOURCE_DIR]);


### PR DESCRIPTION
Since mantis issue 28789 has now the status "fix acc to prio", I tackled that issue myself with a quick fix.

To be able to set the third argument `recursive` to `true`, I also had to set the second argument `mode` to `0777`. This is the default value for `mode` anyway. So as long as PHP doesn't change the default value in it's API, we are safe with this.