### PR TITLE
HSLU FIX: mitigate offset error when updating news period

### DIFF
--- a/components/ILIAS/Block/classes/class.ilBlockGUI.php
+++ b/components/ILIAS/Block/classes/class.ilBlockGUI.php
@@ -207,7 +207,10 @@ abstract class ilBlockGUI
         if ($this->checkOffset($a_offset)) {
             $this->offset = $a_offset;
         } else {
-            throw new ilException("ilBlockGUI::setOffset(): Offset out of range.");
+            // START PATCH HSLU ZEL: mitigate offset error (occurs when changing news settings so that there are not enough items to show anymore to reach the page indicated by the offset)
+            $this->offset = 0;
+//            throw new ilException("ilBlockGUI::setOffset(): Offset out of range.");
+            // END PATCH HSLU ZEL
         }
     }
 


### PR DESCRIPTION
If changing the news period reduces the news items to an amount that makes the current page redundant an offset exception is thrown and the error from then on continually occurrs when one tries to access the dashboard which makes it unusable.
This fix prevents this error from being thrown by setting an out of bounds offset to zero.