### PR TITLE
HSLU FIX: Fix news not being updated after changing period when cache is active

### DIFF
--- a/components/ILIAS/News/src/Domain/NewsCollectionService.php
+++ b/components/ILIAS/News/src/Domain/NewsCollectionService.php
@@ -133,7 +133,11 @@ class NewsCollectionService
 
     public function invalidateCache(int $user_id): void
     {
-        $this->cache->invalidateNewsForUser($user_id, new NewsCriteria());
+        // START PATCH HSLU ZEL: news items were not updated after changing and saving the period in the news settings when caching is active
+        $news_period = ilNewsItem::_lookupUserPDPeriod($user_id);
+        $this->cache->invalidateNewsForUser($user_id, new NewsCriteria(period: $news_period));
+//        $this->cache->invalidateNewsForUser($user_id, new NewsCriteria());
+        // END PATCH HSLU ZEL
     }
 
     /**


### PR DESCRIPTION
The news invalidation which should reload the news once the period is changed does not work when a cache is used.
This fix remedies that by handing over the period which enables the correct cache entry being targeted and deleted so the news will reload after changing settings (as it is supposed to do).