### PR TITLE
HSLU FIX: Exam view title shows escaped HTML for participant name

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -3356,8 +3356,12 @@ JS;
             // this is a placeholder solution with inline html tags to differentiate the different elements
             // should be removed when a title component with grouping and visual weighting is available
             // see:  https://github.com/ILIAS-eLearning/ILIAS/pull/7311
-            $pax_name_value = "<span class='il-test-kiosk-head__participant-name'>"
-                . $this->user->getFullname() . "</span>";
+            // the markup has to be passed as a Legacy component, since string values of a property
+            // listing are escaped by the renderer and would end up as visible markup in the title
+            $pax_name_value = $this->ui_factory->legacy(
+                "<span class='il-test-kiosk-head__participant-name'>"
+                . htmlspecialchars($this->user->getFullname(), ENT_QUOTES, 'UTF-8') . "</span>"
+            );
             $title_content = $title_content->withProperty($pax_name_label, $pax_name_value, false);
         }
 


### PR DESCRIPTION
It's an upstream ILIAS 10 regression: the Test component still relies on the old raw-string behaviour, and the code comment right above it even admits it's a placeholder hack awaiting a real title component (ILIAS PR #7311).
Fix: Pass the markup as a Legacy component, which is rendered raw, and escape the user's full name explicitly so it cannot inject markup itself.
